### PR TITLE
Use matching argument name in get_form_temp()

### DIFF
--- a/R/get_form_data.R
+++ b/R/get_form_data.R
@@ -40,10 +40,10 @@ download_form_file <- function(ps_url, name, output_dir = NULL) {
 #'
 #' @inheritParams get_ps_url
 #' @return The name of the temporary file.
-get_form_temp <- function(form_handle_id, form_data_id) {
-  ps_url <- get_ps_url(form_handle_id, form_data_id)
+get_form_temp <- function(file_handle_id, form_data_id) {
+  ps_url <- get_ps_url(file_handle_id, form_data_id)
   filename <- tempfile(
-    pattern = glue::glue("form_{form_handle_id}_data_{form_data_id}"),
+    pattern = glue::glue("form_{file_handle_id}_data_{form_data_id}"),
     fileext = ".json"
   )
   download_form_file(ps_url, name = filename)

--- a/man/get_form_temp.Rd
+++ b/man/get_form_temp.Rd
@@ -4,9 +4,11 @@
 \alias{get_form_temp}
 \title{Download submission to temp file}
 \usage{
-get_form_temp(form_handle_id, form_data_id)
+get_form_temp(file_handle_id, form_data_id)
 }
 \arguments{
+\item{file_handle_id}{The fileHandleId for the submission.}
+
 \item{form_data_id}{The formDataId for the submission.}
 }
 \value{


### PR DESCRIPTION
`get_form_temp()` inherits parameter documentation from `get_ps_url()` but one of the arguments had a different name. I'm guessing they were meant to match, but let me know if not.