### PR TITLE
Fix an error in documentation when changing submission column name

### DIFF
--- a/R/get-sub-info.R
+++ b/R/get-sub-info.R
@@ -69,7 +69,7 @@ get_main_sections <- function(data, id) {
 #'   "exercise.pullups.reps.max", "2", NA
 #' )
 #' data <- make_tidier_table(data)
-#' get_ids(data)
+#' get_submission_ids(data)
 get_submission_ids <- function(data) {
   all_ids <- unique(data$form_data_id)
   all_ids

--- a/man/get_submission_ids.Rd
+++ b/man/get_submission_ids.Rd
@@ -28,5 +28,5 @@ data <- tibble::tribble(
   "exercise.pullups.reps.max", "2", NA
 )
 data <- make_tidier_table(data)
-get_ids(data)
+get_submission_ids(data)
 }


### PR DESCRIPTION
Had a silly documentation error in PR #15 that made the example fail. Fixed it.