### PR TITLE
Reduce the number of tidier columns

### DIFF
--- a/R/organize-data.R
+++ b/R/organize-data.R
@@ -1,16 +1,13 @@
 #' Make submissions table more tidy
 #'
 #' Make the submissions table more tidy. New table will have
-#' columns "form_data_id", "section", "variable", "sub_variable",
+#' columns "form_data_id", "section", "variable",
 #' "response". Submission ids are moved to the "form_data_id"
 #' column from the original column names. Submission responses
 #' are moved to the "response" column, and "variables" that
-#' correspond to the responses are broken into the three
-#' columns "section", "variable", "sub_variable". These three
-#' columns fill from the left, leaving `NA` in the right-most
-#' column(s) if there are not enough pieces to the variable or
-#' merging the remaining variable pieces if there are more
-#' than three pieces to the variable. See the example for
+#' correspond to the responses are broken into the two
+#' columns "section" and "variable". These two
+#' columns fill from the left. See the example for
 #' clarification.
 #'
 #' @export
@@ -39,7 +36,7 @@ make_tidier_table <- function(data) {
   data <- tidyr::separate(
     data,
     variables,
-    into = c("section", "variable", "sub_variable"),
+    into = c("section", "variable"),
     sep = "[.]",
     remove = TRUE,
     extra = "merge",
@@ -49,7 +46,6 @@ make_tidier_table <- function(data) {
     "form_data_id",
     "section",
     "variable",
-    "sub_variable",
     "response"
   )]
   data

--- a/man/make_tidier_table.Rd
+++ b/man/make_tidier_table.Rd
@@ -14,16 +14,13 @@ with the form_data_id as the column name.}
 }
 \description{
 Make the submissions table more tidy. New table will have
-columns "form_data_id", "section", "variable", "sub_variable",
+columns "form_data_id", "section", "variable",
 "response". Submission ids are moved to the "form_data_id"
 column from the original column names. Submission responses
 are moved to the "response" column, and "variables" that
-correspond to the responses are broken into the three
-columns "section", "variable", "sub_variable". These three
-columns fill from the left, leaving `NA` in the right-most
-column(s) if there are not enough pieces to the variable or
-merging the remaining variable pieces if there are more
-than three pieces to the variable. See the example for
+correspond to the responses are broken into the two
+columns "section" and "variable". These two
+columns fill from the left. See the example for
 clarification.
 }
 \examples{

--- a/tests/testthat/test-organize-data.R
+++ b/tests/testthat/test-organize-data.R
@@ -17,12 +17,8 @@ test_that("make_tidier_table returns tidier table", {
       "s1", "s1", "s2", "s2"
     ),
     variable = c(
-      "a", "b", "a", "b",
-      "a", "b", "a", "b"
-    ),
-    sub_variable = c(
-      NA, "1", "1", "1.apple",
-      NA, "1", "1", "1.apple"
+      "a", "b.1", "a.1", "b.1.apple",
+      "a", "b.1", "a.1", "b.1.apple"
     ),
     response = c(
       NA, "yes", "no", "jane",


### PR DESCRIPTION
`make_tidier_table()` breaks the json variables into three columns, "section", "variable", "sub_variable". I originally did this since it could help with synapseforms. However, it ends up that it would be easy to only break this into two columns, "section" and "variable". This also fits better for a more general-purpose function. This update removes the "sub_variable" column and only splits off the json variable into "section" and "variable".