### PR TITLE
Return NULL if no submissions for state_filter given

### DIFF
--- a/R/get-submission-metadata.R
+++ b/R/get-submission-metadata.R
@@ -9,7 +9,8 @@
 #'   Filters are: `WAITING_FOR_SUBMISSION`, `SUBMITTED_WAITING_FOR_REVIEW`,
 #'   `ACCEPTED`, `REJECTED`. Only accepts one filter.
 #' @param group The groupID.
-#' @return A dataframe of the submission metadata.
+#' @return A dataframe of the submission metadata, or NULL if there are
+#'   no submissions that meet the criteria.
 #' @examples
 #' \dontrun{
 #'
@@ -35,6 +36,9 @@ get_submissions_metadata <- function(syn, state_filter = "SUBMITTED_WAITING_FOR_
     uri = "https://repo-prod.prod.sagebase.org/repo/v1/form/data/list/reviewer",
     body = body
   )
+  if (length(response$page) == 0) {
+    return(NULL)
+  }
   metadata <- get_json_as_df(response$page)
 
   while (length(response) == 2) {

--- a/man/get_submissions_metadata.Rd
+++ b/man/get_submissions_metadata.Rd
@@ -20,7 +20,8 @@ Filters are: `WAITING_FOR_SUBMISSION`, `SUBMITTED_WAITING_FOR_REVIEW`,
 \item{group}{The groupID.}
 }
 \value{
-A dataframe of the submission metadata.
+A dataframe of the submission metadata, or NULL if there are
+  no submissions that meet the criteria.
 }
 \description{
 Get the metadata for all submissions by state filter:


### PR DESCRIPTION
If a state_filter had no submissions associated with it (ex: no ACCEPTED submissions), then there would be an error since it would try to make an empty list into a dataframe. Instead, simply return NULL if no submissions were retrieved.