### PR TITLE
Construct file paths with fs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Description: The synapseforms packages gathers submission metadata
 Imports:
   curl,
   dplyr,
+  fs,
   glue,
   jsonlite,
   purrr,

--- a/R/get-form-data.R
+++ b/R/get-form-data.R
@@ -30,7 +30,7 @@ download_form_file <- function(ps_url, name, output_dir = NULL) {
   if (is.null(output_dir)) {
     curl::curl_download(ps_url, destfile = name)
   } else {
-    curl::curl_download(ps_url, destfile = glue::glue("{output_dir}{name}"))
+    curl::curl_download(ps_url, destfile = fs::path(output_dir, name))
   }
 }
 


### PR DESCRIPTION
I ran into this when trying to download a file -- I specified the output dir as `"~/Desktop"` and the file got saved as `"Desktoptest.json"` in my home directory because I didn't include a trailing slash in the directory name. It's generally safer to construct paths with functions specifically designed for that, rather than using string manipulation. You avoid this type of issue (see example below), things are more likely to work cross-platform, etc. 

``` r
output_dir1 <- "~/Desktop"
output_dir2 <- "~/Desktop/"
name <- "test.json"
fs::path(output_dir1, name)
#> ~/Desktop/test.json
fs::path(output_dir2, name)
#> ~/Desktop/test.json
```

<sup>Created on 2020-01-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>