### PR TITLE
Send back temp file list in a better way

### DIFF
--- a/R/download-all-submissions.R
+++ b/R/download-all-submissions.R
@@ -46,7 +46,5 @@ download_all_submissions_temp <- function(syn, state_filter = "SUBMITTED_WAITING
       get_form_temp(syn, handle, id)
     }
   )
-  names(file_list) <- subs_meta$formDataId
-
-  file_list
+  unlist(file_list)
 }


### PR DESCRIPTION
When downloading all the submission files as temporary JSON files, the list of file names I was sending back was unwieldy. Instead of naming the list, simply unlist (to remove extra layer added by `purrr::map2()`), and send back this list of character strings with the temp file names.