### PR TITLE
Better file list take two

### DIFF
--- a/R/download-all-submissions.R
+++ b/R/download-all-submissions.R
@@ -34,7 +34,8 @@ download_all_submissions_local <- function(syn, state_filter = "SUBMITTED_WAITIN
 #' @param syn Synapse login object
 #' @param state_filter The filter that is desired to gather submissions by.
 #' @param group The groupID.
-#' @return List of temporary filenames.
+#' @return Named list of temporary filenames, where the name is
+#'   the `formDataId`.
 download_all_submissions_temp <- function(syn, state_filter = "SUBMITTED_WAITING_FOR_REVIEW", # nolint
                                           group) {
   subs_meta <- get_submissions_metadata(syn, state_filter, group)
@@ -47,4 +48,6 @@ download_all_submissions_temp <- function(syn, state_filter = "SUBMITTED_WAITING
     }
   )
   unlist(file_list)
+  names(file_list) <- subs_meta$formDataId
+  file_list
 }

--- a/R/download-all-submissions.R
+++ b/R/download-all-submissions.R
@@ -46,7 +46,5 @@ download_all_submissions_temp <- function(syn, state_filter = "SUBMITTED_WAITING
       get_form_temp(syn, handle, id)
     }
   )
-  names(file_list) <- subs_meta$formDataId
-
-  file_list
+  unlist(file_list)
 }

--- a/man/download_all_submissions_temp.Rd
+++ b/man/download_all_submissions_temp.Rd
@@ -18,7 +18,8 @@ download_all_submissions_temp(
 \item{group}{The groupID.}
 }
 \value{
-List of temporary filenames.
+Named list of temporary filenames, where the name is
+  the `formDataId`.
 }
 \description{
 Download all submissions to temporary files.


### PR DESCRIPTION
Realized that the formDataId gets lost if the file list doesn't have those as the names. Instead, unlist to reduce the layering from purrr and then name with formDataId. Makes for better list than the original one.