### PR TITLE
Remove unnecessary package management and update lock file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,12 +26,8 @@ Imports:
   tidyr,
   magrittr
 Suggests:
-  devtools,
-  lintr,
-  styler,
-  testthat,
-  covr
+  testthat
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "3.6.1",
+    "Version": "3.6.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -53,17 +53,17 @@
     },
     "callr": {
       "Package": "callr",
-      "Version": "3.3.2",
+      "Version": "3.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3826226af5ca33cd8fa0b1d9c190b300"
+      "Hash": "189949090a9c879871a2f35e01c53174"
     },
     "cli": {
       "Package": "cli",
-      "Version": "1.1.0",
+      "Version": "2.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9b3dc7798f53ba3050b41ce4a3febdc5"
+      "Hash": "ad09a20ef22a37821c922cfa3978df1a"
     },
     "crayon": {
       "Package": "crayon",
@@ -88,10 +88,10 @@
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.23",
+      "Version": "0.6.25",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ed4a691194af45374f99d2d700400240"
+      "Hash": "4aa1fb41cb0420edbb9a44b088cc92aa"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -116,24 +116,31 @@
     },
     "fansi": {
       "Package": "fansi",
-      "Version": "0.4.0",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "cd87b0162287f0da225edfaa2fd3a20c"
+      "Hash": "b95a15fe144c0db82f8f55cd961b4961"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1f486e04f4b44ee5bfc0aff3651644b0"
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.3.1",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e8436e647719b7c9d01409767cd88cc8"
+      "Hash": "d91320fca0edff2378184a44bec3f3f9"
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.6",
+      "Version": "1.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b7e67b6a7bc2fdae729c0f3ff9026a8a"
+      "Hash": "725056796d6009be6f51d9d0cd40cca1"
     },
     "lattice": {
       "Package": "lattice",
@@ -254,10 +261,10 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "0.4.2",
+      "Version": "0.4.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d963fc6d77b53554f438d82ef8cbea62"
+      "Hash": "06c992bbca11c557891193289cb02d30"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -268,10 +275,10 @@
     },
     "rstudioapi": {
       "Package": "rstudioapi",
-      "Version": "0.10",
+      "Version": "0.11",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "04552808fd065fdf0fec7bad340eb83c"
+      "Hash": "0d9551fe403c7a8fdaabe6d1982aeb3d"
     },
     "stringi": {
       "Package": "stringi",
@@ -282,10 +289,10 @@
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "2.3.1",
+      "Version": "2.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4d84e1019512baaf629c87edfd270f22"
+      "Hash": "ba91292dc6d4d91f24d6bde8ef12ed56"
     },
     "tibble": {
       "Package": "tibble",

--- a/renv.lock
+++ b/renv.lock
@@ -123,10 +123,10 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.3.2",
+      "Version": "1.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1f486e04f4b44ee5bfc0aff3651644b0"
+      "Hash": "3c3a21a20eb921daa47cafe3e24c55b6"
     },
     "glue": {
       "Package": "glue",


### PR DESCRIPTION
These are causing problems when testing the package in GH Actions. They are not needed for the package so removing these.

@karawoo, since I updated the lock file, I'd greatly appreciate it if you could check that it still works correctly for your system whenever you get a chance.