### PR TITLE
Update all calls to internal functions to use named parameters

### DIFF
--- a/R/convert-json-to-table.R
+++ b/R/convert-json-to-table.R
@@ -31,7 +31,7 @@ convert_all_forms_to_table <- function(file_list = NULL, directory = NULL) {
     sub_tables <- purrr::map(
       file_list,
       function(file) {
-        get_json_unlisted_table(file)
+        get_json_unlisted_table(filepath = file)
       }
     )
   } else {
@@ -39,7 +39,7 @@ convert_all_forms_to_table <- function(file_list = NULL, directory = NULL) {
       file_list,
       names(file_list),
       function(file, name) {
-        get_json_unlisted_table(file, name)
+        get_json_unlisted_table(filepath = file, name = name)
       }
     )
   }

--- a/R/download-all-submissions.R
+++ b/R/download-all-submissions.R
@@ -9,7 +9,7 @@
 download_all_submissions_local <- function(syn, group, output_dir,
                                            state_filter = "SUBMITTED_WAITING_FOR_REVIEW") { # nolint
   subs_meta <- get_submissions_metadata(
-    syn,
+    syn = syn,
     group = group,
     all_users = TRUE,
     state_filter = state_filter
@@ -19,7 +19,7 @@ download_all_submissions_local <- function(syn, group, output_dir,
     subs_meta$dataFileHandleId,
     subs_meta$formDataId,
     function(handle, id) {
-      get_ps_url(syn, handle, id)
+      get_ps_url(syn = syn, file_handle_id = handle, form_data_id = id)
     }
   )
   # Download all files
@@ -27,7 +27,7 @@ download_all_submissions_local <- function(syn, group, output_dir,
     ps_url_list,
     subs_meta$name,
     function(url, name) {
-      download_form_file(url, name, output_dir = output_dir)
+      download_form_file(ps_url = url, name = name, output_dir = output_dir)
     }
   )
 }
@@ -45,7 +45,7 @@ download_all_submissions_local <- function(syn, group, output_dir,
 download_all_submissions_temp <- function(syn, group,
                                           state_filter = "SUBMITTED_WAITING_FOR_REVIEW") { # nolint
   subs_meta <- get_submissions_metadata(
-    syn,
+    syn = syn,
     group = group,
     all_users = TRUE,
     state_filter = state_filter
@@ -55,7 +55,7 @@ download_all_submissions_temp <- function(syn, group,
     subs_meta$dataFileHandleId,
     subs_meta$formDataId,
     function(handle, id) {
-      get_form_temp(syn, handle, id)
+      get_ps_url(syn = syn, file_handle_id = handle, form_data_id = id)
     }
   )
   unlist(file_list)

--- a/R/get-form-data.R
+++ b/R/get-form-data.R
@@ -43,11 +43,15 @@ download_form_file <- function(ps_url, name, output_dir = NULL) {
 #' @inheritParams get_ps_url
 #' @return The name of the temporary file.
 get_form_temp <- function(syn, file_handle_id, form_data_id) {
-  ps_url <- get_ps_url(syn, file_handle_id, form_data_id)
+  ps_url <- get_ps_url(
+    syn = syn,
+    file_handle_id = file_handle_id,
+    form_data_id = form_data_id
+  )
   filename <- tempfile(
     pattern = glue::glue("form_{file_handle_id}_data_{form_data_id}"),
     fileext = ".json"
   )
-  download_form_file(ps_url, name = filename)
+  download_form_file(ps_url = ps_url, name = filename)
   filename
 }

--- a/R/get-submission-metadata.R
+++ b/R/get-submission-metadata.R
@@ -47,7 +47,7 @@ get_submissions_metadata <- function(syn, group, all_users = TRUE,
   if (length(response$page) == 0) {
     return(NULL)
   }
-  metadata <- get_json_as_df(response$page)
+  metadata <- get_json_as_df(data = response$page)
 
   while (length(response) == 2) {
     body <- glue::glue('{{"filterByState":["{state_filter}"],"groupId":"{group}","nextPageToken":"{response$nextPageToken}"}}') # nolint
@@ -55,7 +55,7 @@ get_submissions_metadata <- function(syn, group, all_users = TRUE,
       uri = uri,
       body = body
     )
-    temp_metadata <- get_json_as_df(response$page)
+    temp_metadata <- get_json_as_df(data = response$page)
     metadata <- rbind(metadata, temp_metadata)
   }
   metadata

--- a/R/main.R
+++ b/R/main.R
@@ -9,11 +9,16 @@
 #' @param state_filter The filter that is desired to gather submissions by.
 #' @param group The groupID.
 #' @param output_dir The directory to output the submissions and csv file to.
-download_all_and_output_to_csv <- function(syn, state_filter = "SUBMITTED_WAITING_FOR_REVIEW", # nolint
-                                           group, output_dir) {
-  download_all_submissions_local(syn, state_filter, group, output_dir)
+download_all_and_output_to_csv <- function(syn, group, output_dir,
+                                           state_filter = "SUBMITTED_WAITING_FOR_REVIEW") { # nolint
+  download_all_submissions_local(
+    syn = syn,
+    state_filter = state_filter,
+    group = group,
+    output_dir = output_dir
+  )
   data <- convert_all_forms_to_table(directory = output_dir)
-  output_submission_csv(data, output_dir)
+  output_submission_csv(data = data, output_dir = output_dir)
 }
 
 #' Get all submissions as single table
@@ -28,7 +33,11 @@ download_all_and_output_to_csv <- function(syn, state_filter = "SUBMITTED_WAITIN
 #' @param group The groupID.
 download_all_and_get_table <- function(syn, group,
                                        state_filter = "SUBMITTED_WAITING_FOR_REVIEW") { # nolint
-  file_list <- download_all_submissions_temp(syn, state_filter, group)
-  data <- convert_all_forms_to_table(file_list)
+  file_list <- download_all_submissions_temp(
+    syn = syn,
+    state_filter = state_filter,
+    group = group
+  )
+  data <- convert_all_forms_to_table(file_list = file_list)
   data
 }

--- a/man/download_all_and_output_to_csv.Rd
+++ b/man/download_all_and_output_to_csv.Rd
@@ -6,19 +6,19 @@
 \usage{
 download_all_and_output_to_csv(
   syn,
-  state_filter = "SUBMITTED_WAITING_FOR_REVIEW",
   group,
-  output_dir
+  output_dir,
+  state_filter = "SUBMITTED_WAITING_FOR_REVIEW"
 )
 }
 \arguments{
 \item{syn}{Synapse login object}
 
-\item{state_filter}{The filter that is desired to gather submissions by.}
-
 \item{group}{The groupID.}
 
 \item{output_dir}{The directory to output the submissions and csv file to.}
+
+\item{state_filter}{The filter that is desired to gather submissions by.}
 }
 \description{
 Download all submissions, process into a single table, and output


### PR DESCRIPTION
Fixes #40.

Changed all calls to internal functions to use named parameters to reduce problems with ordering.
Also changed the ordering of params on `download_all_and_output_to_csv()` so that `state_filter`, which has a default, is at the end.

I tried this out a little, but one of the downsides to this is that I don't have thorough unit tests. If either @karawoo or @philerooski could double check this PR that would be great.