### PR TITLE
add tests for reject_submission

### DIFF
--- a/tests/testthat/test-reject_submission.R
+++ b/tests/testthat/test-reject_submission.R
@@ -9,7 +9,7 @@ test_that("strings are generated from reject_submission", {
   testthat::expect_true(test_reject)
 })
 
-test_that("warning for strings more than 500 chars", {
+test_that("error when strings are more than 500 chars", {
   string <- glue::glue_collapse({seq(1:300)}, sep = ",")
   m <- mockery::mock(TRUE)
   mockery::stub(reject_submission, "rest_put", m)

--- a/tests/testthat/test-reject_submission.R
+++ b/tests/testthat/test-reject_submission.R
@@ -1,0 +1,19 @@
+test_that("strings are generated from reject_submission", {
+  m <- mockery::mock("character strings") # i think this should be a string to mock the reason?
+  mockery::stub(reject_submission, "rest_put", m)
+  test_reject <- reject_submission(syn = "",
+                                   form_data_id = 42,
+                                   reason = "your submission looks good")
+  testthat::expect_vector(test_reject)
+})
+
+test_that("warning for strings more than 500 chars", {
+  string <- glue::glue_collapse({seq(1:300)}, sep = ",")
+  m <- mockery::mock(string)
+  mockery::stub(reject_submission, "rest_put", m)
+  testthat::expect_error(reject_submission(syn = "",
+                                           form_data_id = 42,
+                                           reason = string)
+  )
+
+})

--- a/tests/testthat/test-reject_submission.R
+++ b/tests/testthat/test-reject_submission.R
@@ -1,20 +1,20 @@
 context("accept-reject-submission.R")
 
 test_that("strings are generated from reject_submission", {
-  m <- mockery::mock("character strings") # i think this should be a string to mock the reason?
+  m <- mockery::mock(TRUE)
   mockery::stub(reject_submission, "rest_put", m)
   test_reject <- reject_submission(syn = "",
-                                   form_data_id = 42,
+                                   form_data_id = 1,
                                    reason = "your submission looks good")
-  testthat::expect_vector(test_reject)
+  testthat::expect_true(test_reject)
 })
 
 test_that("warning for strings more than 500 chars", {
   string <- glue::glue_collapse({seq(1:300)}, sep = ",")
-  m <- mockery::mock(string)
+  m <- mockery::mock(TRUE)
   mockery::stub(reject_submission, "rest_put", m)
   testthat::expect_error(reject_submission(syn = "",
-                                           form_data_id = 42,
+                                           form_data_id = 1,
                                            reason = string)
   )
 

--- a/tests/testthat/test-reject_submission.R
+++ b/tests/testthat/test-reject_submission.R
@@ -1,3 +1,5 @@
+context("accept-reject-submission.R")
+
 test_that("strings are generated from reject_submission", {
   m <- mockery::mock("character strings") # i think this should be a string to mock the reason?
   mockery::stub(reject_submission, "rest_put", m)


### PR DESCRIPTION
Fixes #51.

There are two checks: 1. The function returns a string 2. The function returns an error if the string is greater than 500 characters.